### PR TITLE
feat: configure allowed origins via environment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -24,13 +24,20 @@
   # CORS headers para la API
   for = "/api/*"
   [headers.values]
-    Access-Control-Allow-Origin = "*"
+    # Origin permitido definido por variable de entorno
+    Access-Control-Allow-Origin = "${ALLOWED_ORIGIN}"
     Access-Control-Allow-Headers = "Content-Type"
     Access-Control-Allow-Methods = "GET, POST, OPTIONS"
 
 # Variables de entorno requeridas
 [build.environment]
   NODE_VERSION = "18"
+  # Valor por defecto para desarrollo local
+  ALLOWED_ORIGIN = "http://localhost:3000"
+
+[context.production.environment]
+  # Origin permitido en producción
+  ALLOWED_ORIGIN = "https://example.com"
 
 # Configuración de desarrollo local
 [dev]


### PR DESCRIPTION
## Summary
- use `ALLOWED_ORIGIN` env variable for API CORS
- define dev and production origin values in Netlify config

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e18e5ea90832eafc73c971f009a48