### PR TITLE
Add creative mode option for prompts

### DIFF
--- a/index.html
+++ b/index.html
@@ -370,6 +370,16 @@
                 </select>
             </div>
 
+            <div class="option-group">
+                <h3>Mode</h3>
+                <select id="mode">
+                    <option value="standard" selected>Standard</option>
+                    <option value="creative">Creative Touch</option>
+                    <option value="enthusiastic">Enthusiastic</option>
+                    <option value="formal">Formal</option>
+                </select>
+            </div>
+
             <button id="generateBtn" onclick="generatePrompt()">Generate Prompt</button>
 
             <div class="error" id="error"></div>
@@ -410,6 +420,7 @@
             const payload = document.getElementById('payload').value;
             const personality = document.getElementById('personality').value;
             const obfuscation = document.getElementById('obfuscation').value;
+            const mode = document.getElementById('mode').value;
             
             if (!payload.trim()) {
                 showError('Please enter a query');
@@ -436,7 +447,8 @@
                         payload,
                         personality,
                         ofuscation: obfuscation,
-                        contextualization: 'structured_config'
+                        contextualization: 'structured_config',
+                        options: { mode }
                     })
                 });
 

--- a/netlify/functions/generate.js
+++ b/netlify/functions/generate.js
@@ -296,6 +296,16 @@ Respond ONLY with the prompt.`,
             }
         }
 
+        const modeSuffixes = {
+            creative: "LET'S GOOO!!!",
+            enthusiastic: "This is going to be awesome!",
+            formal: "Respectfully,"
+        };
+
+        if (options?.mode && modeSuffixes[options.mode]) {
+            result += `\n${modeSuffixes[options.mode]}`;
+        }
+
         // Successful response with additional metadata
         return {
             statusCode: 200,


### PR DESCRIPTION
## Summary
- add UI option to choose prompt mode, including a creative touch choice
- append `LET'S GOOO!!!` to prompts when creative mode is selected

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688e483e4b0c832ea3dfca33a3629fc9