### PR TITLE
fix: create log directory before writing

### DIFF
--- a/netlify/functions/feedback.js
+++ b/netlify/functions/feedback.js
@@ -18,7 +18,9 @@ exports.handler = async (event) => {
       feedback
     };
 
-    const filePath = path.join(__dirname, '..', 'data', 'feedback.json');
+    const dataDir = path.join(__dirname, '..', 'data');
+    fs.mkdirSync(dataDir, { recursive: true });
+    const filePath = path.join(dataDir, 'feedback.json');
     let logs = [];
     if (fs.existsSync(filePath)) {
       logs = JSON.parse(fs.readFileSync(filePath, 'utf8'));

--- a/netlify/functions/generate.js
+++ b/netlify/functions/generate.js
@@ -323,7 +323,9 @@ Respond ONLY with the prompt.`,
         };
 
         try {
-            const logsPath = path.join(__dirname, '..', 'data', 'usage.json');
+            const dataDir = path.join(__dirname, '..', 'data');
+            fs.mkdirSync(dataDir, { recursive: true });
+            const logsPath = path.join(dataDir, 'usage.json');
             let logs = [];
             if (fs.existsSync(logsPath)) {
                 logs = JSON.parse(fs.readFileSync(logsPath, 'utf8'));


### PR DESCRIPTION
## Summary
- ensure Netlify functions create `netlify/data` directory before writing logs
- avoid ENOENT errors when logging feedback and usage

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cfb8fa18c832e8162d413e486431c